### PR TITLE
CDRW-686 Fake OpenId Authorisation Server Url in Mock Server for initial client redirection

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,5 @@ CLIENT_ID=spoofClientId
 CLIENT_SECRET=spoofClientSecret
 ACCESS_TOKEN=2YotnFZFEjr1zCsicMWpAA
 VERSION=v1.1
+OPENID_CONFIG_ENDPOINT_URL=http://localhost:$PORT/openid/config
+OPENID_ASPSP_AUTH_HOST=http://localhost:$PORT

--- a/lib/app.js
+++ b/lib/app.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { OBAccountPaymentServiceProviders } = require('./ob-directory');
 const { authServer } = require('./auth-server');
 const { accountRequests } = require('./account-requests');
+const { openIdConfig } = require('./open-id-config');
 const bodyParser = require('body-parser');
 
 const app = express();
@@ -12,6 +13,7 @@ app.post('/token', authServer);
 app.post('/account-requests', accountRequests.post);
 app.get('/account-requests/:id', accountRequests.get);
 app.delete('/account-requests/:id', accountRequests.del);
+app.get('/openid/config/:id', openIdConfig.get);
 app.use('/scim/v2/OBAccountPaymentServiceProviders', OBAccountPaymentServiceProviders);
 
 exports.app = app;

--- a/lib/ob-directory.js
+++ b/lib/ob-directory.js
@@ -1,5 +1,5 @@
-
-const aspsp = (name, fapiFinancialId) => ({
+const openId = process.env.OPENID_CONFIG_ENDPOINT_URL;
+const aspsp = (name, fapiFinancialId, openIdConfigEndpointUrl) => ({
   AuthorisationServers: [{
     AutoRegistrationSupported: true,
     BaseApiDNSUri: `http://${fapiFinancialId}.example.com`,
@@ -8,7 +8,7 @@ const aspsp = (name, fapiFinancialId) => ({
     CustomerFriendlyLogoUri: '',
     CustomerFriendlyName: name,
     DeveloperPortalUri: 'string',
-    OpenIDConfigEndPointUri: 'string',
+    OpenIDConfigEndPointUri: openIdConfigEndpointUrl,
     PayloadSigningCertLocation: 'string',
     TermsOfService: 'string',
   }],
@@ -19,9 +19,9 @@ const aspsp = (name, fapiFinancialId) => ({
 const OBAccountPaymentServiceProviders = (req, res) => {
   res.json({
     Resources: [
-      aspsp('AAA Example Bank', 'aaa-example-bank'),
-      aspsp('BBB Example Bank', 'bbb-example-bank'),
-      aspsp('CCC Example Bank', 'ccc-example-bank'),
+      aspsp('AAA Example Bank', 'aaa-example-bank', `${openId}/aaa-example-bank`),
+      aspsp('BBB Example Bank', 'bbb-example-bank', `${openId}/bbb-example-bank`),
+      aspsp('CCC Example Bank', 'ccc-example-bank', `${openId}/ccc-example-bank`)
     ],
   });
 };

--- a/lib/ob-directory.js
+++ b/lib/ob-directory.js
@@ -1,4 +1,6 @@
-const openId = process.env.OPENID_CONFIG_ENDPOINT_URL;
+const env = require('env-var');
+
+const openId = env.get('OPENID_CONFIG_ENDPOINT_URL').asString();
 const aspsp = (name, fapiFinancialId, openIdConfigEndpointUrl) => ({
   AuthorisationServers: [{
     AutoRegistrationSupported: true,

--- a/lib/ob-directory.js
+++ b/lib/ob-directory.js
@@ -21,7 +21,7 @@ const OBAccountPaymentServiceProviders = (req, res) => {
     Resources: [
       aspsp('AAA Example Bank', 'aaa-example-bank', `${openId}/aaa-example-bank`),
       aspsp('BBB Example Bank', 'bbb-example-bank', `${openId}/bbb-example-bank`),
-      aspsp('CCC Example Bank', 'ccc-example-bank', `${openId}/ccc-example-bank`)
+      aspsp('CCC Example Bank', 'ccc-example-bank', `${openId}/ccc-example-bank`),
     ],
   });
 };

--- a/lib/open-id-config.js
+++ b/lib/open-id-config.js
@@ -1,0 +1,12 @@
+const openidAspspAuthHost = process.env.OPENID_ASPSP_AUTH_HOST;
+const log = require('debug')('log');
+
+const get = (req, res) => {
+  log(`http get open id config for aspsp: [${req.params.id}]`);
+  res.json({
+    authorization_endpoint: `${openidAspspAuthHost}/authorize`,
+    token_endpoint: `${openidAspspAuthHost}/token`,
+  });
+};
+
+exports.openIdConfig = { get };

--- a/lib/open-id-config.js
+++ b/lib/open-id-config.js
@@ -1,5 +1,7 @@
-const openidAspspAuthHost = process.env.OPENID_ASPSP_AUTH_HOST;
+const env = require('env-var');
 const log = require('debug')('log');
+
+const openidAspspAuthHost = env.get('OPENID_ASPSP_AUTH_HOST').asString();
 
 const get = (req, res) => {
   log(`http get open id config for aspsp: [${req.params.id}]`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/node": {
+      "version": "8.0.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.47.tgz",
+      "integrity": "sha512-kOwL746WVvt/9Phf6/JgX/bsGQvbrK5iUgzyfwZNcKVFcjAUVSpF9HxevLTld2SG9aywYHOILj38arDdY1r/iQ=="
+    },
     "accepts": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
@@ -299,6 +304,11 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
+    },
+    "camelcase": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
     "chai": {
       "version": "3.5.0",
@@ -615,6 +625,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
+    "env-var": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/env-var/-/env-var-3.0.2.tgz",
+      "integrity": "sha1-+7r0I0GUBdZt5Q4urbwBIYOpnas=",
+      "requires": {
+        "@types/node": "8.0.47",
+        "camelcase": "4.1.0",
+        "is-url": "1.2.2"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
@@ -973,6 +993,16 @@
       "requires": {
         "flat-cache": "1.3.0",
         "object-assign": "4.1.1"
+      }
+    },
+    "fill-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+      "integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
+      "dev": true,
+      "requires": {
+        "is-object": "1.0.1",
+        "merge-descriptors": "1.0.1"
       }
     },
     "finalhandler": {
@@ -1336,6 +1366,12 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
     "is-path-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
@@ -1374,6 +1410,11 @@
       "requires": {
         "tryit": "1.0.3"
       }
+    },
+    "is-url": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
+      "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY="
     },
     "isarray": {
       "version": "0.0.1",
@@ -2028,6 +2069,12 @@
         }
       }
     },
+    "module-not-found-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+      "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
+      "dev": true
+    },
     "morgan": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
@@ -2462,6 +2509,25 @@
       "requires": {
         "forwarded": "0.1.2",
         "ipaddr.js": "1.4.0"
+      }
+    },
+    "proxyquire": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
+      "integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
+      "dev": true,
+      "requires": {
+        "fill-keys": "1.0.2",
+        "module-not-found-error": "1.0.1",
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
       }
     },
     "pseudomap": {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   "keywords": [],
   "license": "MIT",
   "dependencies": {
-    "body-parser": "^1.18.2",
     "axios": "^0.16.2",
+    "body-parser": "^1.18.2",
     "debug": "^3.1.0",
+    "env-var": "3.0.2",
     "express": "^4.15.5",
     "mkdirp": "^0.5.1",
     "morgan": "^1.9.0",
@@ -36,6 +37,7 @@
     "eslint-plugin-import": "^2.7.0",
     "foreman": "^2.0.0",
     "mocha": "^3.5.0",
+    "proxyquire": "1.8.0",
     "sinon": "^4.0.0",
     "supertest": "^3.0.0"
   }

--- a/test/aspsp-test.js
+++ b/test/aspsp-test.js
@@ -1,5 +1,8 @@
 const assert = require('assert');
 const request = require('supertest'); // eslint-disable-line
+const OPENID_CONFIG_ENDPOINT_URL = 'http://localhost';
+
+process.env.OPENID_CONFIG_ENDPOINT_URL = OPENID_CONFIG_ENDPOINT_URL;
 const { app } = require('../lib/app.js');
 
 describe('/scim/v2/OBAccountPaymentServiceProviders', () => {
@@ -8,12 +11,14 @@ describe('/scim/v2/OBAccountPaymentServiceProviders', () => {
       .get('/scim/v2/OBAccountPaymentServiceProviders')
       .set('Accept', 'application/json')
       .end((err, res) => {
+        const authServer = res.body.Resources[0].AuthorisationServers[0];
         assert.equal(res.status, 200);
         assert.equal(res.body.Resources.length, 3);
-        assert.equal(res.body.Resources[0].AuthorisationServers[0].CustomerFriendlyName, 'AAA Example Bank');
         assert.equal(res.body.Resources[0].id, 'aaa-example-bank');
-        assert.equal(res.body.Resources[0].AuthorisationServers[0].BaseApiDNSUri, 'http://aaa-example-bank.example.com');
-        assert.equal(res.body.Resources[0].AuthorisationServers[0].CustomerFriendlyLogoUri, '');
+        assert.equal(authServer.CustomerFriendlyName, 'AAA Example Bank');
+        assert.equal(authServer.BaseApiDNSUri, 'http://aaa-example-bank.example.com');
+        assert.equal(authServer.CustomerFriendlyLogoUri, '');
+        assert.equal(authServer.OpenIDConfigEndPointUri, `${OPENID_CONFIG_ENDPOINT_URL}/${res.body.Resources[0].id}`);
         done();
       });
   });

--- a/test/aspsp-test.js
+++ b/test/aspsp-test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const request = require('supertest'); // eslint-disable-line
-const OPENID_CONFIG_ENDPOINT_URL = 'http://localhost';
+const OPENID_CONFIG_ENDPOINT_URL = 'http://localhost/openid/config';
 
 process.env.OPENID_CONFIG_ENDPOINT_URL = OPENID_CONFIG_ENDPOINT_URL;
 const { app } = require('../lib/app.js');

--- a/test/openid-test.js
+++ b/test/openid-test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const request = require('supertest'); // eslint-disable-line
+const proxyquire = require('proxyquire');
+const env = require('env-var');
+
+describe('/openid/config/:id', () => {
+  let oid, app;
+
+  before(function () {
+    oid = proxyquire('../lib/open-id-config.js', {
+      'env-var': env.mock({
+        OPENID_ASPSP_AUTH_HOST: 'http://localhost'
+      })
+    });
+
+    app = proxyquire('../lib/app.js', { './open-id-config': oid }).app;
+  });
+
+  it('returns JSON payload', (done) => {
+    request(app)
+      .get('/openid/config/aaa-example-bank')
+      .set('Accept', 'application/json')
+      .end((err, res) => {
+        const oidConfig = res.body;
+        assert.equal(res.status, 200);
+        assert.equal(oidConfig.authorization_endpoint, `http://localhost/authorize`);
+        assert.equal(oidConfig.token_endpoint, `http://localhost/token`);
+        done();
+      });
+  });
+});

--- a/test/openid-test.js
+++ b/test/openid-test.js
@@ -3,28 +3,33 @@ const request = require('supertest'); // eslint-disable-line
 const proxyquire = require('proxyquire');
 const env = require('env-var');
 
-describe('/openid/config/:id', () => {
-  let oid, app;
+const host = 'http://localhost';
 
-  before(function () {
+describe('/openid/config/:id', () => {
+  let oid;
+  let server;
+
+  before(() => {
     oid = proxyquire('../lib/open-id-config.js', {
       'env-var': env.mock({
-        OPENID_ASPSP_AUTH_HOST: 'http://localhost'
-      })
+        OPENID_ASPSP_AUTH_HOST: host,
+      }),
     });
 
-    app = proxyquire('../lib/app.js', { './open-id-config': oid }).app;
+    server = proxyquire('../lib/app.js', {
+      './open-id-config': oid,
+    });
   });
 
   it('returns JSON payload', (done) => {
-    request(app)
+    request(server.app)
       .get('/openid/config/aaa-example-bank')
       .set('Accept', 'application/json')
       .end((err, res) => {
         const oidConfig = res.body;
         assert.equal(res.status, 200);
-        assert.equal(oidConfig.authorization_endpoint, `http://localhost/authorize`);
-        assert.equal(oidConfig.token_endpoint, `http://localhost/token`);
+        assert.equal(oidConfig.authorization_endpoint, `${host}/authorize`);
+        assert.equal(oidConfig.token_endpoint, `${host}/token`);
         done();
       });
   });


### PR DESCRIPTION
Exposes a mock OpenID Config endpoint. This endpoint is found here `/openid/config/:id`. It provides links to:
* `/token` endpoint.
* `/authorize` endpoint.

Also, updated the ASPSP payloads to include a `OpenIDConfigEndPointUri`. This points to the above path.
