### PR TITLE
Change token response to comply with RFC

### DIFF
--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -60,6 +60,7 @@ const createToken = (req, res) => {
   const grantType = req.body.grant_type;
   const { scope } = req.body;
   const { authorization } = req.headers;
+  res.set('Content-Type', 'application/json;charset=UTF-8');
   try {
     checkParamsPresent(scope, grantType, authorization);
     if (authenticate(grantType, authorization)) {

--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -41,17 +41,20 @@ const authenticate = (grantType, authorization) => {
 const checkParamsPresent = (scope, grantType, authorization) => {
   if (!scope) {
     const error = new Error('scope missing from request body');
+    error.error = 'invalid_request'; // See: https://tools.ietf.org/html/rfc6749#section-5.2
     error.status = 400;
     throw error;
   }
   if (!grantType) {
     const error = new Error('grant_type missing from request body');
+    error.error = 'invalid_request'; // See: https://tools.ietf.org/html/rfc6749#section-5.2
     error.status = 400;
     throw error;
   }
   if (!authorization) {
     const error = new Error('authorization missing from request headers');
-    error.status = 401;
+    error.error = 'invalid_client'; // See: https://tools.ietf.org/html/rfc6749#section-5.2
+    error.status = 400;
     throw error;
   }
 };
@@ -60,7 +63,7 @@ const createToken = (req, res) => {
   const grantType = req.body.grant_type;
   const { scope } = req.body;
   const { authorization } = req.headers;
-  res.set('Content-Type', 'application/json;charset=UTF-8');
+  res.set('Content-Type', 'application/json; charset=UTF-8');
   try {
     checkParamsPresent(scope, grantType, authorization);
     if (authenticate(grantType, authorization)) {
@@ -78,9 +81,16 @@ const createToken = (req, res) => {
     log('authentication failed');
     return res.sendStatus(401);
   } catch (err) {
-    const status = err.status || 500;
     log(err);
-    return res.sendStatus(status);
+    if (err.status && err.error) {
+      return res
+        .status(err.status)
+        .send({
+          error: err.error,
+          error_description: err.message,
+        });
+    }
+    return res.sendStatus(500);
   }
 };
 

--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -79,7 +79,7 @@ const createToken = (req, res) => {
       });
     }
     log('authentication failed');
-    return res.sendStatus(401);
+    return res.status(400).send({ error: 'invalid_grant' });
   } catch (err) {
     log(err);
     if (err.status && err.error) {

--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -64,7 +64,10 @@ const createToken = (req, res) => {
   try {
     checkParamsPresent(scope, grantType, authorization);
     if (authenticate(grantType, authorization)) {
+      // Successful Response see: https://tools.ietf.org/html/rfc6749#section-5.1
       const accessToken = makeAccessToken();
+      res.set('Cache-Control', 'no-store');
+      res.set('Pragma', 'no-store');
       return res.json({
         access_token: accessToken,
         expires_in: ONE_HOUR,

--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -79,7 +79,8 @@ const createToken = (req, res) => {
       });
     }
     log('authentication failed');
-    return res.status(400).send({ error: 'invalid_grant' });
+    res.set('WWW-Authenticate', 'client_credentials');
+    return res.status(401).send({ error: 'invalid_client' });
   } catch (err) {
     log(err);
     if (err.status && err.error) {

--- a/test/aspsp-authorisation-server/token-test.js
+++ b/test/aspsp-authorisation-server/token-test.js
@@ -63,4 +63,10 @@ describe('createToken', () => {
       token_type: 'bearer',
     });
   });
+
+  it('sets Content-Type to application/json;charset=UTF-8', async () => {
+    const res = await requestToken(validCredentials);
+    assert.ok(res.headers['content-type']);
+    assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+  });
 });

--- a/test/aspsp-authorisation-server/token-test.js
+++ b/test/aspsp-authorisation-server/token-test.js
@@ -35,12 +35,13 @@ describe('createToken', () => {
       .send(body);
   };
 
-  it('returns 400 when credentials invalid', async () => {
+  it('returns 401 when credentials invalid', async () => {
     const invalidCredentials = credentials('bad-id', 'bad-secret');
     const res = await requestToken(invalidCredentials);
-    assert.equal(res.status, 400);
+    assert.equal(res.status, 401);
+    assert.equal(res.headers['www-authenticate'], 'client_credentials');
     assert.deepEqual(res.body, {
-      error: 'invalid_grant',
+      error: 'invalid_client',
     });
   });
 

--- a/test/aspsp-authorisation-server/token-test.js
+++ b/test/aspsp-authorisation-server/token-test.js
@@ -24,10 +24,13 @@ describe('createToken', () => {
       scope: 'accounts',
       grant_type: 'client_credentials',
     };
-    return request(app)
+    let requestObj = request(app)
       .post('/token')
-      .set('Accept', 'application/json')
-      .set('authorization', authCredentials)
+      .set('Accept', 'application/json');
+    if (authCredentials) {
+      requestObj = requestObj.set('authorization', authCredentials);
+    }
+    return requestObj
       .set('content-type', 'application/x-www-form-urlencoded')
       .send(body);
   };
@@ -38,19 +41,31 @@ describe('createToken', () => {
     assert.equal(res.status, 401);
   });
 
-  it('returns 401 when credentials blank', async () => {
+  it('returns 400 when credentials not send', async () => {
     const res = await requestToken(null);
-    assert.equal(res.status, 401);
+    assert.equal(res.status, 400);
+    assert.deepEqual(res.body, {
+      error: 'invalid_client',
+      error_description: 'authorization missing from request headers',
+    });
   });
 
   it('returns 400 when grant_type missing', async () => {
     const res = await requestToken(validCredentials, { scope: 'accounts' });
     assert.equal(res.status, 400);
+    assert.deepEqual(res.body, {
+      error: 'invalid_request',
+      error_description: 'grant_type missing from request body',
+    });
   });
 
   it('returns 400 when scope missing', async () => {
     const res = await requestToken(validCredentials, { grant_type: 'client_credentials' });
     assert.equal(res.status, 400);
+    assert.deepEqual(res.body, {
+      error: 'invalid_request',
+      error_description: 'scope missing from request body',
+    });
   });
 
   it('returns access token payload when credentials valid', async () => {

--- a/test/aspsp-authorisation-server/token-test.js
+++ b/test/aspsp-authorisation-server/token-test.js
@@ -69,4 +69,16 @@ describe('createToken', () => {
     assert.ok(res.headers['content-type']);
     assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
   });
+
+  it('sets no-store in Cache-Control header', async () => {
+    const res = await requestToken(validCredentials);
+    assert.ok(res.headers['cache-control']);
+    assert.equal(res.headers['cache-control'], 'no-store');
+  });
+
+  it('sets no-store in Pragma header', async () => {
+    const res = await requestToken(validCredentials);
+    assert.ok(res.headers.pragma);
+    assert.equal(res.headers.pragma, 'no-store');
+  });
 });

--- a/test/aspsp-authorisation-server/token-test.js
+++ b/test/aspsp-authorisation-server/token-test.js
@@ -35,10 +35,13 @@ describe('createToken', () => {
       .send(body);
   };
 
-  it('returns 401 when credentials invalid', async () => {
+  it('returns 400 when credentials invalid', async () => {
     const invalidCredentials = credentials('bad-id', 'bad-secret');
     const res = await requestToken(invalidCredentials);
-    assert.equal(res.status, 401);
+    assert.equal(res.status, 400);
+    assert.deepEqual(res.body, {
+      error: 'invalid_grant',
+    });
   });
 
   it('returns 400 when credentials not send', async () => {


### PR DESCRIPTION
To comply with [rfc6749](https://tools.ietf.org/html/rfc6749#section-5.1):
- Set content-type on /token response
- Set cache-control and pragma on /token response
- Set error body on /token response body as per rfc

For #CDRW-755