### PR TITLE
Refactor token endpoint with functionality for authorization code grant type

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -24,7 +24,7 @@ const asyncInvoker = async (req, res, next, fn) => {
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 
-app.post('/token', createToken);
+app.post('/:id/token', createToken);
 app.get('/:id/authorize', (req, res, next) => asyncInvoker(req, res, next, authorise));
 app.post('/account-requests', accountRequests.post);
 app.get('/account-requests/:id', accountRequests.get);

--- a/lib/aspsp-authorisation-server/authorise.js
+++ b/lib/aspsp-authorisation-server/authorise.js
@@ -65,7 +65,7 @@ const authorise = (req, res) => {
   const authorizationCode = generateAuthorisationCode();
 
   const stateRedirectionValue = state ? `&state=${state}` : '';
-  const aspspCallbackRedirectionUrl = `${redirectUrl}?authorization-code=${authorizationCode}${stateRedirectionValue}`;
+  const aspspCallbackRedirectionUrl = `${redirectUrl}?code=${authorizationCode}${stateRedirectionValue}`;
   res.redirect(302, aspspCallbackRedirectionUrl);
 };
 

--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -4,8 +4,16 @@
  * If credentials match then an auth token is returned.
  */
 const log = require('debug')('log');
+const AuthenticationException = require('../errors/AuthenticationException')
 
 const ONE_HOUR = 3600;
+const GRANT_AUTHORIZATION_CODE = 'authorization_code';
+const GRANT_CLINET_CREDENTIALS = 'client_credentials';
+
+const ERROR_INVALID_REQUEST = 'invalid_request';
+const ERROR_INVALID_CLIENT = 'invalid_client';
+
+
 
 const clientCredentials = () => ({
   clientId: process.env.CLIENT_ID,
@@ -30,69 +38,49 @@ const credentials = (id, secret) => {
  * @param grantType
  * @param authorization
  */
+const ValidationException = require('../errors/ValidationException');
+
 const authenticate = (grantType, authorization) => {
   const { clientId, clientSecret } = clientCredentials();
   const expectedCredentials = credentials(clientId, clientSecret);
-  const authenticated = (authorization === expectedCredentials)
-    && (grantType === 'client_credentials');
-  return authenticated;
+  if (authorization !== expectedCredentials
+    || (grantType !== GRANT_CLINET_CREDENTIALS && grantType !== GRANT_AUTHORIZATION_CODE)) {
+    throw (new AuthenticationException()).addPayload({ error: ERROR_INVALID_CLIENT }).addHeader('WWW-Authenticate', grantType);
+  }
 };
 
 const checkParamsPresent = (scope, grantType, authorization) => {
   if (!scope) {
-    const error = new Error('scope missing from request body');
-    error.error = 'invalid_request'; // See: https://tools.ietf.org/html/rfc6749#section-5.2
-    error.status = 400;
-    throw error;
+    throw (new ValidationException('scope missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
   }
   if (!grantType) {
-    const error = new Error('grant_type missing from request body');
-    error.error = 'invalid_request'; // See: https://tools.ietf.org/html/rfc6749#section-5.2
-    error.status = 400;
-    throw error;
+    throw (new ValidationException('grant_type missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
   }
   if (!authorization) {
-    const error = new Error('authorization missing from request headers');
-    error.error = 'invalid_client'; // See: https://tools.ietf.org/html/rfc6749#section-5.2
-    error.status = 400;
-    throw error;
+    throw (new ValidationException('authorization missing from request headers')).setPayload({ error: ERROR_INVALID_CLIENT });
   }
 };
 
 const createToken = (req, res) => {
   const grantType = req.body.grant_type;
   const { scope } = req.body;
+  const { 'code': authorizationCode } = req.body;
   const { authorization } = req.headers;
+
   res.set('Content-Type', 'application/json; charset=UTF-8');
-  try {
-    checkParamsPresent(scope, grantType, authorization);
-    if (authenticate(grantType, authorization)) {
-      // Successful Response see: https://tools.ietf.org/html/rfc6749#section-5.1
-      const accessToken = makeAccessToken();
-      res.set('Cache-Control', 'no-store');
-      res.set('Pragma', 'no-store');
-      return res.json({
-        access_token: accessToken,
-        expires_in: ONE_HOUR,
-        token_type: 'bearer',
-        scope,
-      });
-    }
-    log('authentication failed');
-    res.set('WWW-Authenticate', 'client_credentials');
-    return res.status(401).send({ error: 'invalid_client' });
-  } catch (err) {
-    log(err);
-    if (err.status && err.error) {
-      return res
-        .status(err.status)
-        .send({
-          error: err.error,
-          error_description: err.message,
-        });
-    }
-    return res.sendStatus(500);
-  }
+  checkParamsPresent(scope, grantType, authorization);
+
+  authenticate(grantType, authorization);
+  // Successful Response see: https://tools.ietf.org/html/rfc6749#section-5.1
+  const accessToken = makeAccessToken();
+  res.set('Cache-Control', 'no-store');
+  res.set('Pragma', 'no-store');
+  return res.json({
+    access_token: accessToken,
+    expires_in: ONE_HOUR,
+    token_type: 'bearer',
+    scope,
+  });
 };
 
 exports.credentials = credentials;

--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -49,28 +49,33 @@ const authenticate = (grantType, authorization) => {
 
 const commonParamsValidation = (grantType, authorization) => {
   if (!grantType) {
-    throw (new ValidationException('grant_type missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
+    throw (new ValidationException('grant_type missing from request body'))
+      .setPayload({ error: ERROR_INVALID_REQUEST });
   }
   if (!authorization) {
-    throw (new ValidationException('authorization missing from request headers')).setPayload({ error: ERROR_INVALID_CLIENT });
+    throw (new ValidationException('authorization missing from request headers'))
+      .setPayload({ error: ERROR_INVALID_CLIENT });
   }
 };
 
 const validateScope = (scope) => {
   if (!scope) {
-    throw (new ValidationException('scope missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
+    throw (new ValidationException('scope missing from request body'))
+      .setPayload({ error: ERROR_INVALID_REQUEST });
   }
 };
 
 const validateAuthorisationCode = (authorizationCode) => {
   if (!authorizationCode) {
-    throw (new ValidationException('authorisation code missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
+    throw (new ValidationException('authorisation code missing from request body'))
+      .setPayload({ error: ERROR_INVALID_REQUEST });
   }
 };
 
 const validateRedirectUrl = (redirectUrl) => {
   if (!redirectUrl) {
-    throw (new ValidationException('redirect url missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
+    throw (new ValidationException('redirect url missing from request body'))
+      .setPayload({ error: ERROR_INVALID_REQUEST });
   }
 };
 
@@ -126,7 +131,8 @@ const createToken = (req, res) => {
   } else if (isAuthorisationCodeFlow(grantType)) {
     createTokenForAuthorsationCode(req, res);
   } else {
-    throw (new ValidationException('unsupported grant_type')).setPayload({ error: ERROR_UNSUPPORTED_GRANT_TYPE });
+    throw (new ValidationException('unsupported grant_type'))
+      .setPayload({ error: ERROR_UNSUPPORTED_GRANT_TYPE });
   }
 };
 

--- a/lib/aspsp-authorisation-server/token.js
+++ b/lib/aspsp-authorisation-server/token.js
@@ -3,8 +3,8 @@
  * (hard coded - see .env.sample file for values) to what is expected.
  * If credentials match then an auth token is returned.
  */
-const log = require('debug')('log');
-const AuthenticationException = require('../errors/AuthenticationException')
+const AuthenticationException = require('../errors/AuthenticationException');
+const ValidationException = require('../errors/ValidationException');
 
 const ONE_HOUR = 3600;
 const GRANT_AUTHORIZATION_CODE = 'authorization_code';
@@ -12,8 +12,7 @@ const GRANT_CLINET_CREDENTIALS = 'client_credentials';
 
 const ERROR_INVALID_REQUEST = 'invalid_request';
 const ERROR_INVALID_CLIENT = 'invalid_client';
-
-
+const ERROR_UNSUPPORTED_GRANT_TYPE = 'unsupported_grant_type';
 
 const clientCredentials = () => ({
   clientId: process.env.CLIENT_ID,
@@ -38,7 +37,6 @@ const credentials = (id, secret) => {
  * @param grantType
  * @param authorization
  */
-const ValidationException = require('../errors/ValidationException');
 
 const authenticate = (grantType, authorization) => {
   const { clientId, clientSecret } = clientCredentials();
@@ -49,10 +47,7 @@ const authenticate = (grantType, authorization) => {
   }
 };
 
-const checkParamsPresent = (scope, grantType, authorization) => {
-  if (!scope) {
-    throw (new ValidationException('scope missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
-  }
+const commonParamsValidation = (grantType, authorization) => {
   if (!grantType) {
     throw (new ValidationException('grant_type missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
   }
@@ -61,26 +56,78 @@ const checkParamsPresent = (scope, grantType, authorization) => {
   }
 };
 
-const createToken = (req, res) => {
-  const grantType = req.body.grant_type;
+const validateScope = (scope) => {
+  if (!scope) {
+    throw (new ValidationException('scope missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
+  }
+};
+
+const validateAuthorisationCode = (authorizationCode) => {
+  if (!authorizationCode) {
+    throw (new ValidationException('authorisation code missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
+  }
+};
+
+const validateRedirectUrl = (redirectUrl) => {
+  if (!redirectUrl) {
+    throw (new ValidationException('redirect url missing from request body')).setPayload({ error: ERROR_INVALID_REQUEST });
+  }
+};
+
+const isClientCredentialsFlow = grantType => grantType === GRANT_CLINET_CREDENTIALS;
+const isAuthorisationCodeFlow = grantType => grantType === GRANT_AUTHORIZATION_CODE;
+
+const createTokenForClientCredentials = (req, res) => {
   const { scope } = req.body;
-  const { 'code': authorizationCode } = req.body;
-  const { authorization } = req.headers;
 
-  res.set('Content-Type', 'application/json; charset=UTF-8');
-  checkParamsPresent(scope, grantType, authorization);
+  validateScope(scope);
+  const token = makeAccessToken();
 
-  authenticate(grantType, authorization);
   // Successful Response see: https://tools.ietf.org/html/rfc6749#section-5.1
-  const accessToken = makeAccessToken();
+  res.set('Content-Type', 'application/json; charset=UTF-8');
   res.set('Cache-Control', 'no-store');
   res.set('Pragma', 'no-store');
   return res.json({
-    access_token: accessToken,
+    access_token: token,
     expires_in: ONE_HOUR,
     token_type: 'bearer',
     scope,
   });
+};
+
+const createTokenForAuthorsationCode = (req, res) => {
+  const { 'code': authorizationCode, 'redirect_url': redirectUrl } = req.body;
+
+  validateAuthorisationCode(authorizationCode);
+  validateRedirectUrl(redirectUrl);
+  const token = makeAccessToken();
+
+  // Successful Response see: https://tools.ietf.org/html/rfc6749#section-5.1
+  res.set('Content-Type', 'application/json; charset=UTF-8');
+  res.set('Cache-Control', 'no-store');
+  res.set('Pragma', 'no-store');
+  return res.json({
+    access_token: token,
+    expires_in: ONE_HOUR,
+    token_type: 'bearer',
+  });
+};
+
+const createToken = (req, res) => {
+  const grantType = req.body.grant_type;
+  const { authorization } = req.headers;
+
+  res.set('Content-Type', 'application/json; charset=UTF-8');
+  commonParamsValidation(grantType, authorization);
+  authenticate(grantType, authorization);
+
+  if (isClientCredentialsFlow(grantType)) {
+    createTokenForClientCredentials(req, res);
+  } else if (isAuthorisationCodeFlow(grantType)) {
+    createTokenForAuthorsationCode(req, res);
+  } else {
+    throw (new ValidationException('unsupported grant_type')).setPayload({ error: ERROR_UNSUPPORTED_GRANT_TYPE });
+  }
 };
 
 exports.credentials = credentials;

--- a/lib/errors/AuthenticationException.js
+++ b/lib/errors/AuthenticationException.js
@@ -1,0 +1,27 @@
+module.exports = class AuthenticationException extends Error {
+  constructor(...params) {
+    super(...params);
+
+    Error.captureStackTrace(this, AuthenticationException);
+    this.h = new Map();
+    this.p = null;
+  }
+
+  addHeader(key, value) {
+    this.h.set(key, value);
+    return this;
+  }
+
+  get headers() {
+    return this.h;
+  }
+
+  get payload() {
+    return this.p;
+  }
+
+  addPayload(p) {
+    this.p = p;
+    return this;
+  }
+};

--- a/lib/errors/ValidationException.js
+++ b/lib/errors/ValidationException.js
@@ -3,5 +3,15 @@ module.exports = class ValidationException extends Error {
     super(...params);
 
     Error.captureStackTrace(this, ValidationException);
+    this.p = null;
+  }
+
+  get payload() {
+    return this.p;
+  }
+
+  setPayload(p) {
+    this.p = p;
+    return this;
   }
 };

--- a/lib/errors/error-handler.js
+++ b/lib/errors/error-handler.js
@@ -53,7 +53,9 @@ const handler = (err, req, res, next) => { // eslint-disable-line
 };
 
 const logger = (err, req, res, next) => {
-  error(`${errorType(err)} => ${err.stack}`);
+  if (process.env.NODE_ENV !== 'test') {
+    error(`${errorType(err)} => ${err.stack}`);
+  }
   next(err);
 };
 

--- a/lib/errors/error-handler.js
+++ b/lib/errors/error-handler.js
@@ -1,4 +1,4 @@
-const log = require('debug')('log');
+const error = require('debug')('error');
 
 const errorType = (err) => {
   const ret = (!!err && !!err.constructor && !!err.constructor.name) ? err.constructor.name : 'Error';
@@ -43,17 +43,17 @@ const handler = (err, req, res, next) => { // eslint-disable-line
         break;
       }
       default:
-        console.log(err);
+        error(err);
         next(err);
     }
   } catch (unhandledError) {
-    console.log(unhandledError);
+    error(unhandledError);
     next(unhandledError);
   }
 };
 
 const logger = (err, req, res, next) => {
-  log(`${errorType(err)} => ${err.stack}`);
+  error(`${errorType(err)} => ${err.stack}`);
   next(err);
 };
 

--- a/lib/errors/error-handler.js
+++ b/lib/errors/error-handler.js
@@ -7,26 +7,48 @@ const errorType = (err) => {
 
 const handler = (err, req, res, next) => { // eslint-disable-line
   const errClassName = errorType(err);
-  switch (errClassName) {
-    case 'ValidationException':
-      res.status(400).send(err.message);
-      break;
-    case 'RedirectionException': {
-      const entries = Object.entries(err.queryParams);
-      const query = entries
-        .map((q) => {
-          const ret = `${q[0]}=${q[1]}`;
-          return ret;
-        })
-        .reduce((comb, p) => {
-          const ret = `${comb}&${p}`;
-          return ret;
+  try {
+    switch (errClassName) {
+      case 'ValidationException': {
+        let response;
+        if (err.payload) {
+          response = err.payload;
+          response.error_description = err.message;
+        } else {
+          response = err.message;
+        }
+        res.status(400).send(response);
+        break;
+      }
+      case 'RedirectionException': {
+        const entries = Object.entries(err.queryParams);
+        const query = entries
+          .map((q) => {
+            const ret = `${q[0]}=${q[1]}`;
+            return ret;
+          })
+          .reduce((comb, p) => {
+            const ret = `${comb}&${p}`;
+            return ret;
+          });
+        res.redirect(302, `${err.redirectionUrl}?${query}`);
+        break;
+      }
+      case 'AuthenticationException': {
+        const { headers, payload } = err;
+        headers.forEach((name, value) => {
+          res.set(value, name);
         });
-      res.redirect(302, `${err.redirectionUrl}?${query}`);
-      break;
+        res.status(401).send(payload);
+        break;
+      }
+      default:
+        console.log(err);
+        next(err);
     }
-    default:
-      res.redirect(500, 'Unknown server error');
+  } catch (unhandledError) {
+    console.log(unhandledError);
+    next(unhandledError);
   }
 };
 

--- a/test/aspsp-authorisation-server/authorise-test.js
+++ b/test/aspsp-authorisation-server/authorise-test.js
@@ -36,7 +36,7 @@ describe('/authorize endpoint test', () => {
         const { location } = res.header;
         assert.ok(location);
         assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
-        assert.ok(location.includes(`authorization-code=${authorsationCode}`));
+        assert.ok(location.includes(`code=${authorsationCode}`));
         assert.ok(location.includes(`state=${state}`));
         done();
       });
@@ -51,7 +51,7 @@ describe('/authorize endpoint test', () => {
         const { location } = res.header;
         assert.ok(location);
         assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
-        assert.ok(location.includes('?authorization-code'));
+        assert.ok(location.includes('?code'));
         assert.ok(!location.includes('state'));
         done();
       });
@@ -84,7 +84,7 @@ describe('/authorize endpoint test', () => {
         const { location } = res.header;
         assert.ok(location);
         assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
-        assert.ok(!location.includes('authorization-code'));
+        assert.ok(!location.includes('code'));
         assert.ok(location.includes(`state=${state}`));
         assert.ok(location.includes('error=invalid_request'));
         done();
@@ -99,7 +99,7 @@ describe('/authorize endpoint test', () => {
         const { location } = res.header;
         assert.ok(location);
         assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
-        assert.ok(!location.includes('authorization-code'));
+        assert.ok(!location.includes('code'));
         assert.ok(!location.includes('state'));
         assert.ok(location.includes('error=invalid_request'));
         done();
@@ -114,7 +114,7 @@ describe('/authorize endpoint test', () => {
         const { location } = res.header;
         assert.ok(location);
         assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
-        assert.ok(!location.includes('authorization-code'));
+        assert.ok(!location.includes('code'));
         assert.ok(location.includes(`state=${state}`));
         assert.ok(location.includes('error=unsupported_response_type'));
         done();
@@ -129,7 +129,7 @@ describe('/authorize endpoint test', () => {
         const { location } = res.header;
         assert.ok(location);
         assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
-        assert.ok(!location.includes('authorization-code'));
+        assert.ok(!location.includes('code'));
         assert.ok(location.includes(`state=${state}`));
         assert.ok(location.includes('error=invalid_scope'));
         done();

--- a/test/aspsp-authorisation-server/token-test.js
+++ b/test/aspsp-authorisation-server/token-test.js
@@ -25,7 +25,7 @@ describe('createToken', () => {
       grant_type: 'client_credentials',
     };
     return request(app)
-      .post('/token')
+      .post('/abc/token')
       .set('Accept', 'application/json')
       .set('authorization', authCredentials)
       .set('content-type', 'application/x-www-form-urlencoded')

--- a/test/aspsp-authorisation-server/token-test.js
+++ b/test/aspsp-authorisation-server/token-test.js
@@ -19,7 +19,7 @@ describe('createToken', () => {
     process.env.CLIENT_SECRET = null;
   });
 
-  const requestToken = (authCredentials, data) => {
+  const requestTokenForClientCredentials = (authCredentials, data) => {
     const body = data || {
       scope: 'accounts',
       grant_type: 'client_credentials',
@@ -35,9 +35,26 @@ describe('createToken', () => {
       .send(body);
   };
 
+  const requestTokenForAuthorizationCode = (authCredentials, data) => {
+    const body = data || {
+      grant_type: 'authorization_code',
+      redirect_url: 'some-redirect-url',
+      code: 'sample-authorization-code',
+    };
+    let requestObj = request(app)
+      .post('/abc/token')
+      .set('Accept', 'application/json');
+    if (authCredentials) {
+      requestObj = requestObj.set('authorization', authCredentials);
+    }
+    return requestObj
+      .set('content-type', 'application/x-www-form-urlencoded')
+      .send(body);
+  };
+
   it('returns 401 when credentials invalid', async () => {
     const invalidCredentials = credentials('bad-id', 'bad-secret');
-    const res = await requestToken(invalidCredentials);
+    const res = await requestTokenForClientCredentials(invalidCredentials);
     assert.equal(res.status, 401);
     assert.equal(res.headers['www-authenticate'], 'client_credentials');
     assert.deepEqual(res.body, {
@@ -46,7 +63,7 @@ describe('createToken', () => {
   });
 
   it('returns 400 when credentials not send', async () => {
-    const res = await requestToken(null);
+    const res = await requestTokenForClientCredentials(null);
     assert.equal(res.status, 400);
     assert.deepEqual(res.body, {
       error: 'invalid_client',
@@ -54,17 +71,8 @@ describe('createToken', () => {
     });
   });
 
-  it('returns 400 when grant_type missing', async () => {
-    const res = await requestToken(validCredentials, { scope: 'accounts' });
-    assert.equal(res.status, 400);
-    assert.deepEqual(res.body, {
-      error: 'invalid_request',
-      error_description: 'grant_type missing from request body',
-    });
-  });
-
-  it('returns 400 when scope missing', async () => {
-    const res = await requestToken(validCredentials, { grant_type: 'client_credentials' });
+  it('returns 400 when scope missing in client credentials flow', async () => {
+    const res = await requestTokenForClientCredentials(validCredentials, { grant_type: 'client_credentials' });
     assert.equal(res.status, 400);
     assert.deepEqual(res.body, {
       error: 'invalid_request',
@@ -72,8 +80,26 @@ describe('createToken', () => {
     });
   });
 
-  it('returns access token payload when credentials valid', async () => {
-    const res = await requestToken(validCredentials);
+  it('returns 400 when authorization code is missing in authorization code flow', async () => {
+    const res = await requestTokenForClientCredentials(validCredentials, { grant_type: 'authorization_code' });
+    assert.equal(res.status, 400);
+    assert.deepEqual(res.body, {
+      error: 'invalid_request',
+      error_description: 'authorisation code missing from request body',
+    });
+  });
+
+  it('returns 400 when redirect url is missing in authorization code flow', async () => {
+    const res = await requestTokenForClientCredentials(validCredentials, { grant_type: 'authorization_code', code: '123' });
+    assert.equal(res.status, 400);
+    assert.deepEqual(res.body, {
+      error: 'invalid_request',
+      error_description: 'redirect url missing from request body',
+    });
+  });
+
+  it('returns access token payload for client credentials flow when credentials valid', async () => {
+    const res = await requestTokenForClientCredentials(validCredentials);
     assert.equal(res.status, 200);
     assert.deepEqual(res.body, {
       access_token: accessToken,
@@ -83,20 +109,48 @@ describe('createToken', () => {
     });
   });
 
-  it('sets Content-Type to application/json;charset=UTF-8', async () => {
-    const res = await requestToken(validCredentials);
+  it('sets Content-Type to application/json;charset=UTF-8 in client credentials flow', async () => {
+    const res = await requestTokenForClientCredentials(validCredentials);
     assert.ok(res.headers['content-type']);
     assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
   });
 
-  it('sets no-store in Cache-Control header', async () => {
-    const res = await requestToken(validCredentials);
+  it('sets no-store in Cache-Control header in client credentials flow', async () => {
+    const res = await requestTokenForClientCredentials(validCredentials);
     assert.ok(res.headers['cache-control']);
     assert.equal(res.headers['cache-control'], 'no-store');
   });
 
-  it('sets no-store in Pragma header', async () => {
-    const res = await requestToken(validCredentials);
+  it('sets no-store in Pragma header in client credentials flow', async () => {
+    const res = await requestTokenForClientCredentials(validCredentials);
+    assert.ok(res.headers.pragma);
+    assert.equal(res.headers.pragma, 'no-store');
+  });
+
+  it('returns access token payload for authorization code flow when credentials valid', async () => {
+    const res = await requestTokenForAuthorizationCode(validCredentials);
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body, {
+      access_token: accessToken,
+      expires_in: 3600,
+      token_type: 'bearer',
+    });
+  });
+
+  it('sets Content-Type to application/json;charset=UTF-8 in authorization code flow', async () => {
+    const res = await requestTokenForAuthorizationCode(validCredentials);
+    assert.ok(res.headers['content-type']);
+    assert.equal(res.headers['content-type'], 'application/json; charset=utf-8');
+  });
+
+  it('sets no-store in Cache-Control header in authorization code flow', async () => {
+    const res = await requestTokenForAuthorizationCode(validCredentials);
+    assert.ok(res.headers['cache-control']);
+    assert.equal(res.headers['cache-control'], 'no-store');
+  });
+
+  it('sets no-store in Pragma header in authorization code flow', async () => {
+    const res = await requestTokenForAuthorizationCode(validCredentials);
     assert.ok(res.headers.pragma);
     assert.equal(res.headers.pragma, 'no-store');
   });


### PR DESCRIPTION
- refactor token creation endpoint to support client credentials and authorization code grant type flows
- use new error handler for handling errors in create token endpoint
- added new error AuthenticationException
- adjust ValidationException to handle a payload