### PR TITLE
Preperation for release notes v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ curl https://<newname>.herokuapp.com/health
 # OK
 
 # Or if using [httpie](https://httpie.org/), e.g. brew install httpie
-http --json https://<newname>.herokuapp.com/healts
+http --json https://<newname>.herokuapp.com/health
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,18 @@ heroku config:set OPENID_ASPSP_AUTH_HOST=https://<heroku-host-domain>
 git push heroku master
 ```
 
-To test:
+To test (basic):
+```sh
+curl https://<newname>.herokuapp.com/health
 
+# OK
+
+# Or if using [httpie](https://httpie.org/), e.g. brew install httpie
+http --json https://<newname>.herokuapp.com/healts
+
+```
+
+To test (advanced):
 ```sh
 curl -H "x-fapi-financial-id: abcbank" \
      -H "Authorization: alice" \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reference-mock-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Read/Write API mock data server",
   "author": "Open Banking Limited",
   "main": "lib/index.js",


### PR DESCRIPTION
Based on major merges in the past 14 days on the REPO, this is a draft for the release notes.

```
Server stubs some endpoints to return static mock data for:
- Open Banking Account Information API
-- ASPSP Authentication Server (ASPSP AS) API
-- ASPSP Resource Server (ASPSP RS) API
- OB Directory API
- OpenId Configuration 

Given request headers`Authorization: alice` and `x-fapi-financial-id: abcbank` these stubbed endpoints return mock data:
- `/open-banking/v1.1/accounts`
- `/open-banking/v1.1/accounts/22290/balances`
- `/open-banking/v1.1/accounts/22290/product`
- `/open-banking/v1.1/accounts/22291/balances`
- `/open-banking/v1.1/accounts/22291/product`
- `/open-banking/v1.1/accounts/22292/balances`
- `/open-banking/v1.1/accounts/22292/product`

Changes this release:
- Update ASPSP AP server POST /token (client-credentials flow) to be in line with https://tools.ietf.org/html/rfc6749#section-4.3.3
- Add GET /authorize endpoint in ASPSP AP to simulate redirection to ASPSP for user's consent
- Simulate retrieval of OpenId Configuration for ASPSP 
- Add GET /health endpoint
- Add default error handler for Express
```
This PR includes:
- Updates to README.
- Release version bump.

Main commits:
https://github.com/OpenBankingUK/reference-mock-server/commit/a183ec7b0891f3a7520f2a3f7f94282a19ffa3c8
https://github.com/OpenBankingUK/reference-mock-server/commit/b8e6856169093a5ff8b196ec0cf36b34744efa6b
https://github.com/OpenBankingUK/reference-mock-server/commit/728c34d1bf09fb300d4da18705652a27747a97ab
https://github.com/OpenBankingUK/reference-mock-server/commit/2343c3a8a8b8198e797f39052364aea77b4e2a13
