### PR TITLE
REFAPP-3 Enable Mutual TLS (MATLS) for all exposed endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,49 @@ http --json https://<newname>.herokuapp.com/open-banking/v1.1/accounts \
      Authorization:alice
 
 ```
+
+## Security certificates in Reference App ecosystem
+
+OpenBanking specification requires all parties to use Mutual TLS for every connection. OpenBanking uses its own Certification Authority certificate created from OpenBanking Root certificate) to sign clients (TPP) and servers (ASPSP) certificates.
+- For ASPSP server certificate in pair with certificate key and CA certificate must be used to secure resources provided by servers.
+- For TPP client certificate in pair with certificate key and CA certificate must be used to establish secured connection with servers (ASPSP Authorization/Resource Server, OpenBanking Directory and OpenId Configuration).
+
+### Reference App with mock server
+For the purpose of Reference App "dummy" CA certificate (for simplicity application does not use any root certificate to sign CA cert), Mock server certificate and TPP Reference Server certificate have been created. Also, Mock server certificate and TPP Reference Server certificate have been signed by "dummy" CA certificate.
+The created certificates allow running MATLS secured Reference App ecosystem on local environment or any hosted version.
+
+### Reference App connected to OpenBankig Directory
+To connect Reference App to sandbox OpenBanking Directory, ReadWrite Mock Server won't be used.
+
+### Own certificates for development environment (not required)
+In case someone would like to create its own certificates, the receipt below explains how this can be done. Bear in mind that TPP Server and Mock Server accepts certificates and key as environment variable encoded using base64. 
+
+**How to create own certificates.**
+
+- Create the CA Key
+openssl genrsa -des3 -out ca.key 4096
+
+- Create the CA Certificate for signing Client/Server Certs (env var CA_CERT)
+openssl req -new -x509 -days 730 -key ca.key -out ca.crt
+
+- Create the Server Key, CSR, and Certificate (env var SERVER_KEY)
+openssl genrsa -des3 -out server.key 1024
+openssl req -new -key server.key -out server.csr
+
+- Remove passphrase from client key 
+chmod 0600 server.key
+ssh-keygen -p -P [PASSPHRASE_FOR_SERVER_CERT] -N ""  -f ./server.key
+
+- Self signing server csr using CA cert and generate server certificate (env var SERVER_CERT)
+openssl x509 -req -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out server.crt
+
+- Create the Client Key and CSR (env var CLIENT_KEY)
+openssl genrsa -des3 -out client.key 1024
+openssl req -new -key client.key -out client.csr
+
+- Remove passphrase from client key 
+chmod 0600 client.key
+ssh-keygen -p -P [PASSPHRASE_FOR_CLIENT_CERT] -N ""  -f ./client.key
+
+- Self signing client csr using CA cert and generate server certificate (env var CLIENT_CERT)
+openssl x509 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt

--- a/index.js
+++ b/index.js
@@ -1,11 +1,22 @@
 if (!process.env.DEBUG) process.env.DEBUG = 'error,log';
 
-const port = (process.env.PORT || 8001);
-const log = require('debug')('log');
+const securedPort = (process.env.SECURED_PORT || 4433);
+const https = require('https');
+
 const { initApp } = require('./lib');
 
+const serverCert = Buffer.from(process.env.SERVER_CERT || '', 'base64').toString();
+const serverKey = Buffer.from(process.env.SERVER_KEY || '', 'base64').toString();
+const caCert = Buffer.from(process.env.CA_CERT || '', 'base64').toString();
+
+const options = {
+  key: serverKey,
+  cert: serverCert,
+  ca: caCert,
+  requestCert: true,
+  rejectUnauthorized: true,
+};
+
 initApp((app) => {
-  app.listen(port, () => {
-    log(`running on localhost:${port} ... `);
-  });
+  https.createServer(options, app).listen(securedPort);
 });


### PR DESCRIPTION
- Create server key, server certificate, certification authority (CA) certificate for local environment (reference application ecosystem)
- Define server/ca certificates and server key as environment variables (encoded using base64)
- Expose express app as MATLS secured using above certificates; clients are required to connect using own client certificate signed using above CA certificate
- Set default application port to 4433 (does not require node app to be run as root)

Documentation:

# Security certificates in Reference App ecosystem

OpenBanking specification requires all parties to use Mutual TLS for every connection. OpenBanking uses its own Certification Authority certificate (created from OpenBanking Root certificate) to sign clients (TPP) and servers (ASPSP) certificates.
- For ASPSP server certificate in pair with certificate key and CA certificate must be used to secure resources provided by servers.
- For TPP client certificate in pair with certificate key and CA certificate must be used to establish secured connection with servers (ASPSP Authorization/Resource Server, OpenBanking Directory and OpenId Configuration).

For the purpose of Reference App "dummy" CA certificate (for simplicity application does not use any root certificate to sign CA cert), Mock server certificate and TPP Reference Server certificate have been created. Also, Mock server certificate and TPP Reference Server certificate have been signed by "dummy" CA certificate.
The created certificates allow running MATLS secured Reference App ecosystem on local environment or any hosted version.
In case someone would like to create its own certificates the receipt below explains how this can be done. Bear in mind that TPP Server and Mock Server accepts certificates and key as global variable encoded using base64. 

**How to create own certificates.**

- Create the CA Key and Certificate for signing Client/Server Certs
openssl genrsa -des3 -out ca.key 4096
openssl req -new -x509 -days 730 -key ca.key -out ca.crt

- Create the Server Key, CSR, and Certificate
openssl genrsa -des3 -out server.key 1024
openssl req -new -key server.key -out server.csr

- Remove passphrase from client key
chmod 0600 server.key
ssh-keygen -p -P [PASSPHRASE_FOR_SERVER_CERT] -N ""  -f ./server.key

- Self signing server csr using CA cert and generate server certificate
openssl x509 -req -days 365 -in server.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out server.crt

- Create the Client Key and CSR
openssl genrsa -des3 -out client.key 1024
openssl req -new -key client.key -out client.csr

- Remove passphrase from client key
chmod 0600 client.key
ssh-keygen -p -P [PASSPHRASE_FOR_CLIENT_CERT] -N ""  -f ./client.key

- Self signing client csr using CA cert and generate server certificate
openssl x509 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt