### PR TITLE
Fix authorise redirect uri param in `/authorise` handler.

### DIFF
--- a/lib/aspsp-authorisation-server/authorise.js
+++ b/lib/aspsp-authorisation-server/authorise.js
@@ -26,21 +26,21 @@ const validateAuthorisationParams = (query) => {
   if (query.state) {
     redirectionParams.state = query.state;
   }
-  if (!query || !query.redirect_url || !query.clientId) {
+  if (!query || !query.redirect_uri || !query.clientId) {
     throw new ValidationException();
   }
 
   if (!query.request || !query.response_type) {
     redirectionParams.error = INVALID_REQUEST;
-    throw new RedirectionException(query.redirect_url, redirectionParams);
+    throw new RedirectionException(query.redirect_uri, redirectionParams);
   }
   if (!!query.response_type && query.response_type !== AUTHORISE_RESPONSE_TYPE) {
     redirectionParams.error = UNSUPPORTED_RESPONSE_TYPE;
-    throw new RedirectionException(query.redirect_url, redirectionParams);
+    throw new RedirectionException(query.redirect_uri, redirectionParams);
   }
   if (!!query.scope && query.scope !== AUTHORISE_SCOPE) {
     redirectionParams.error = INVALID_SCOPE;
-    throw new RedirectionException(query.redirect_url, redirectionParams);
+    throw new RedirectionException(query.redirect_uri, redirectionParams);
   }
 };
 
@@ -53,19 +53,19 @@ const authorise = (req, res) => {
   validateAuthorisationParams(req.query);
 
   const { query } = req;
-  const { redirect_url: redirectUrl } = query;
+  const { redirect_uri: redirectUri } = query;
   const { clientId, state, request: signedJWTrequest } = query;
 
   log(`Validate clientId [${clientId}] & scope`);
 
-  log(`Validate redirect-url client [${redirectUrl}]`);
+  log(`Validate redirect-uri client [${redirectUri}]`);
 
   log(`Validate JWT requrest claim [${signedJWTrequest}]`);
 
   const authorizationCode = generateAuthorisationCode();
 
   const stateRedirectionValue = state ? `&state=${state}` : '';
-  const aspspCallbackRedirectionUrl = `${redirectUrl}?code=${authorizationCode}${stateRedirectionValue}`;
+  const aspspCallbackRedirectionUrl = `${redirectUri}?code=${authorizationCode}${stateRedirectionValue}`;
   res.redirect(302, aspspCallbackRedirectionUrl);
 };
 

--- a/test/aspsp-authorisation-server/authorise-test.js
+++ b/test/aspsp-authorisation-server/authorise-test.js
@@ -29,7 +29,7 @@ describe('/authorize endpoint test', () => {
 
   it('request authorisation code and validate other redirection params (all optional parameters provided)', (done) => {
     request(server.app)
-      .get(`/aaa-bank/authorize?redirect_url=${aspspCallbackRedirectionUrl}&state=${state}&clientId=ABC&response_type=code&request=jwttoken&scope=openid accounts`)
+      .get(`/aaa-bank/authorize?redirect_uri=${aspspCallbackRedirectionUrl}&state=${state}&clientId=ABC&response_type=code&request=jwttoken&scope=openid accounts`)
       .end((err, res) => {
         assert.equal(res.status, 302);
         assert.strictEqual(res.redirect, true);
@@ -44,7 +44,7 @@ describe('/authorize endpoint test', () => {
 
   it('request authorisation code and validate other redirection params (none of optional parameters provided)', (done) => {
     request(server.app)
-      .get(`/aaa-bank/authorize?redirect_url=${aspspCallbackRedirectionUrl}&clientId=ABC&response_type=code&request=jwttoken`)
+      .get(`/aaa-bank/authorize?redirect_uri=${aspspCallbackRedirectionUrl}&clientId=ABC&response_type=code&request=jwttoken`)
       .end((err, res) => {
         assert.equal(res.status, 302);
         assert.strictEqual(res.redirect, true);
@@ -68,7 +68,7 @@ describe('/authorize endpoint test', () => {
 
   it('returns BAD REQUEST when clientId is not provided', (done) => {
     request(server.app)
-      .get(`/aaa-bank/authorize?redirect_url=${aspspCallbackRedirectionUrl}&state=${state}&response_type=code&request=jwttoken`)
+      .get(`/aaa-bank/authorize?redirect_uri=${aspspCallbackRedirectionUrl}&state=${state}&response_type=code&request=jwttoken`)
       .end((err, res) => {
         assert.equal(res.status, 400);
         done();
@@ -77,7 +77,7 @@ describe('/authorize endpoint test', () => {
 
   it('redirects with 302 (FOUND), state and error flag invalid request when response_type is not provided', (done) => {
     request(server.app)
-      .get(`/aaa-bank/authorize?redirect_url=${aspspCallbackRedirectionUrl}&state=${state}&clientId=ABC&request=jwttoken`)
+      .get(`/aaa-bank/authorize?redirect_uri=${aspspCallbackRedirectionUrl}&state=${state}&clientId=ABC&request=jwttoken`)
       .end((err, res) => {
         assert.equal(res.status, 302);
         assert.strictEqual(res.redirect, true);
@@ -92,7 +92,7 @@ describe('/authorize endpoint test', () => {
   });
   it('redirects with 302 (FOUND), error flag invalid request when response_type is not provided and not state', (done) => {
     request(server.app)
-      .get(`/aaa-bank/authorize?redirect_url=${aspspCallbackRedirectionUrl}&clientId=ABC&request=jwttoken`)
+      .get(`/aaa-bank/authorize?redirect_uri=${aspspCallbackRedirectionUrl}&clientId=ABC&request=jwttoken`)
       .end((err, res) => {
         assert.equal(res.status, 302);
         assert.strictEqual(res.redirect, true);
@@ -107,7 +107,7 @@ describe('/authorize endpoint test', () => {
   });
   it('redirects with 302 (FOUND), state and error flag unsupported_response_type when response_type is not supported', (done) => {
     request(server.app)
-      .get(`/aaa-bank/authorize?redirect_url=${aspspCallbackRedirectionUrl}&state=${state}&response_type=not-supported&clientId=ABC&request=jwttoken`)
+      .get(`/aaa-bank/authorize?redirect_uri=${aspspCallbackRedirectionUrl}&state=${state}&response_type=not-supported&clientId=ABC&request=jwttoken`)
       .end((err, res) => {
         assert.equal(res.status, 302);
         assert.strictEqual(res.redirect, true);
@@ -122,7 +122,7 @@ describe('/authorize endpoint test', () => {
   });
   it('redirects with 302 (FOUND), state and error flag invalid_scope when scope is defined but not supported', (done) => {
     request(server.app)
-      .get(`/aaa-bank/authorize?redirect_url=${aspspCallbackRedirectionUrl}&state=${state}&response_type=code&clientId=ABC&request=jwttoken&scope=not-supported`)
+      .get(`/aaa-bank/authorize?redirect_uri=${aspspCallbackRedirectionUrl}&state=${state}&response_type=code&clientId=ABC&request=jwttoken&scope=not-supported`)
       .end((err, res) => {
         assert.equal(res.status, 302);
         assert.strictEqual(res.redirect, true);


### PR DESCRIPTION
Simple PR, `redirect_url` query param now changed to `redirect_uri` for `/authorise` handler.