### PR TITLE
Upgrade to swagger v1.1.1 specs - REFAPP-115

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,7 +1,7 @@
 DEBUG=error,log
 PORT=8001
 HOST=http://localhost:8001
-SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/account-info-1-1-0-swagger.json
+ACCOUNT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/account-info-1-1-0-swagger.json
 PAYMENT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/payment-initiation-1-1-0-swagger.json
 CLIENT_ID=spoofClientId
 CLIENT_SECRET=spoofClientSecret

--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,8 @@
 DEBUG=error,log
 PORT=8001
 HOST=http://localhost:8001
-ACCOUNT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/account-info-1-1-0-swagger.json
-PAYMENT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/payment-initiation-1-1-0-swagger.json
+ACCOUNT_SWAGGER=https://raw.githubusercontent.com/OpenBankingUK/account-info-api-spec/ee715e094a59b37aeec46aef278f528f5d89eb03/dist/v1.1/account-info-swagger.json
+PAYMENT_SWAGGER=https://raw.githubusercontent.com/OpenBankingUK/payment-initiation-api-spec/96307a92e70e209e51710fab54164f6e8d2e61cf/dist/v1.1/payment-initiation-swagger.json
 CLIENT_ID=spoofClientId
 CLIENT_SECRET=spoofClientSecret
 AUTHORISATION_CODE=spoofAuthorisationCode

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Note: latest `master` branch code is actively under development and may not be s
 Mock server reads swagger file to generate endpoints.
 
 The path or URI to the swagger file is passed to
-the mock server on startup using an environment variable `SWAGGER`.
+the mock server on startup using an environment variable `ACCOUNT_SWAGGER`.
 
 Install npm packages:
 
@@ -48,7 +48,7 @@ Or to set environment variables on the command line:
 ```sh
 DEBUG=error,log \
   VERSION=v1.1 \
-  SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/account-info-1-1-0-swagger.json \
+  ACCOUNT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/account-info-1-1-0-swagger.json \
   PAYMENT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/payment-initiation-1-1-0-swagger.json \
   PORT=8001 \
   OPENID_CONFIG_ENDPOINT_URL=http://localhost:$PORT/openid/config \
@@ -60,7 +60,7 @@ DEBUG=error,log \
 
 Set debug log levels using `DEBUG` env var.
 Set API URI version number using `VERSION` env var.
-Set API specification file using `SWAGGER` env var.
+Set API specification file using `ACCOUNT_SWAGGER` env var.
 
 ## ASPSP resource server mock data
 
@@ -118,7 +118,7 @@ heroku apps:rename <newname>
 
 heroku config:set DEBUG=error,log
 
-heroku config:set SWAGGER=swagger-uri
+heroku config:set ACCOUNT_SWAGGER=swagger-uri
 
 heroku config:set VERSION=<version-for-api-uri>
 

--- a/README.md
+++ b/README.md
@@ -23,18 +23,20 @@ Note: latest `master` branch code is actively under development and may not be s
 
 ## To run
 
-Mock server reads swagger file to generate endpoints.
-
-The path or URI to the swagger file is passed to
-the mock server on startup using an environment variable `ACCOUNT_SWAGGER`.
-
 Install npm packages:
 
 ```sh
 npm install
 ```
 
-To run using .env file, make a local .env, and run using foreman:
+Several environment variables are used to configure the mock server.
+
+The mock server reads swagger files to generate endpoints for Account Information
+and Payment Initiation resources. The path or URI to JSON swagger specification
+files are passed on startup using environment variables `ACCOUNT_SWAGGER` and
+`PAYMENT_SWAGGER`.
+
+To run, copy the `.env.sample` file to a local `.env` file, and run using foreman:
 
 ```sh
 cp .env.sample .env
@@ -43,24 +45,22 @@ npm run foreman
 # web.1 | log running on localhost:8001 ...
 ```
 
-Or to set environment variables on the command line:
+The `.env` file configures the following variables:
 
-```sh
-DEBUG=error,log \
-  VERSION=v1.1 \
-  ACCOUNT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/account-info-1-1-0-swagger.json \
-  PAYMENT_SWAGGER=https://www.openbanking.org.uk/wpcore/wp-content/uploads/2017/09/payment-initiation-1-1-0-swagger.json \
-  PORT=8001 \
-  OPENID_CONFIG_ENDPOINT_URL=http://localhost:$PORT/openid/config \
-  OPENID_ASPSP_AUTH_HOST=http://localhost:$PORT \
-  HOST=http://localhost:$PORT \
-  npm start
-# running on localhost:8001 ...
-```
-
-Set debug log levels using `DEBUG` env var.
-Set API URI version number using `VERSION` env var.
-Set API specification file using `ACCOUNT_SWAGGER` env var.
+* `ACCESS_TOKEN=<access-token-value>`
+* `ACCOUNT_SWAGGER=<JSON swagger spec URI or file path>`
+* `AUTHORISATION_CODE=<auth-code-value>`
+* `BANK_DATA_DIRECTORY=abcbank`
+* `CLIENT_ID=<client-id-value>`
+* `CLIENT_SECRET=<client-secret-value>`
+* `DEBUG =error,log`
+* `HOST=http://localhost:8001`
+* `OPENID_ASPSP_AUTH_HOST=http://localhost:8001`
+* `OPENID_CONFIG_ENDPOINT_URL=http://localhost:8001/openid/config`
+* `PAYMENT_SWAGGER=<JSON swagger spec URI or file path>`
+* `PORT=8001`
+* `USER_DATA_DIRECTORY=alice`
+* `VERSION=v1.1`
 
 ## ASPSP resource server mock data
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ The `.env` file configures the following variables:
 Currently mock data is read off the file system.
 
 For example, given the file
-`./data/abcbank/alice/accounts.json` exists, then setting
-request headers `x-fapi-financial-id: abcbank` and `Authorization: alice` when
+`./data/abcbank/alice/accounts.json` exists, then
 GET requesting `/accounts` returns the JSON in that file.
 
 ```sh
@@ -116,17 +115,32 @@ heroku create --region eu
 
 heroku apps:rename <newname>
 
+heroku config:set ACCESS_TOKEN=<access-token-value>
+
+heroku config:set ACCOUNT_SWAGGER=<JSON swagger spec URI>
+
+heroku config:set AUTHORISATION_CODE=<auth-code-value>
+
+heroku config:set BANK_DATA_DIRECTORY=abcbank
+
+heroku config:set CLIENT_ID=<client-id-value>
+
+heroku config:set CLIENT_SECRET=<client-secret-value>
+
 heroku config:set DEBUG=error,log
 
-heroku config:set ACCOUNT_SWAGGER=swagger-uri
+heroku config:set HOST=https://<heroku-host-domain>
 
-heroku config:set VERSION=<version-for-api-uri>
+heroku config:set
+OPENID_ASPSP_AUTH_HOST=https://<heroku-host-domain>
 
 heroku config:set OPENID_CONFIG_ENDPOINT_URL=https://<heroku-host-domain>/openid/config
 
-heroku config:set OPENID_ASPSP_AUTH_HOST=https://<heroku-host-domain>
+heroku config:set PAYMENT_SWAGGER=<JSON swagger spec URI>
 
-heroku config:set HOST=https://<heroku-host-domain>
+heroku config:set USER_DATA_DIRECTORY=alice
+
+heroku config:set VERSION=v1.1
 
 git push heroku master
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ const schemaValidationErrorMiddleware = (err, req, res, next) => { // eslint-dis
   }
 };
 
-const accountSwagger = process.env.ACCOUNT_SWAGGER;
+const accountSwagger = process.env.ACCOUNT_SWAGGER || process.env.SWAGGER; // eslint-disable-line
 const paymentSwagger = process.env.PAYMENT_SWAGGER;
 
 fetchSwagger(paymentSwagger, 'payment-swagger.json').then((paymentSwaggerFile) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ const schemaValidationErrorMiddleware = (err, req, res, next) => { // eslint-dis
   }
 };
 
-const accountSwagger = process.env.SWAGGER;
+const accountSwagger = process.env.ACCOUNT_SWAGGER;
 const paymentSwagger = process.env.PAYMENT_SWAGGER;
 
 fetchSwagger(paymentSwagger, 'payment-swagger.json').then((paymentSwaggerFile) => {

--- a/test/aspsp-resource-server/swagger-test.js
+++ b/test/aspsp-resource-server/swagger-test.js
@@ -10,7 +10,7 @@ const nock = require('nock');
 describe('fetchSwagger', () => {
   const uri = 'https://example.com/path';
 
-  describe('when SWAGGER env contains URI', () => {
+  describe('when swagger path contains URI', () => {
     before(() => {
       sandbox.restore();
     });
@@ -25,7 +25,7 @@ describe('fetchSwagger', () => {
     });
   });
 
-  describe('when SWAGGER env does not contain URI', () => {
+  describe('when swagger path does not contain URI', () => {
     const file = './path/swagger.json';
 
     before(() => {


### PR DESCRIPTION
- Set `v1.1.1` swagger URIs in `.env.sample` file.
- Set URIs to be github commit SHA URIs to fix to `v1.1.1` release.
- Rename `SWAGGER` env var to `ACCOUNT_SWAGGER`, to distinguish from `PAYMENT_SWAGGER`.
- Load `SWAGGER` env var when `ACCOUNT_SWAGGER` not set, for backwards compatibility.

Readme changes:
- Reword section on env vars.
- Remove the section about setting env vars on command line.
- Update heroku env var config section.

Our heroku deploy has been configured with new URIs.

Tested running client e2e tests locally. No code changes were required.