### PR TITLE
Dockerized Mock Server - REFAPP-194

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,7 @@ CLIENT_SECRET=spoofClientSecret
 DEBUG=error,log
 HOST=http://localhost:8001
 OPENID_ASPSP_AUTH_HOST=http://localhost:8001
+OPENID_ASPSP_TOKEN_HOST=http://localhost:8001
 OPENID_CONFIG_ENDPOINT_URL=http://localhost:8001/openid/config
 PAYMENT_SWAGGER=https://raw.githubusercontent.com/OpenBankingUK/payment-initiation-api-spec/96307a92e70e209e51710fab54164f6e8d2e61cf/dist/v1.1/payment-initiation-swagger.json
 PORT=8001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.3-alpine
+FROM node:8.4-alpine
 
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git
@@ -14,4 +14,3 @@ RUN npm install
 RUN cp .env.sample .env
 EXPOSE 8001
 CMD ["npm", "run", "foreman"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:8.3-alpine
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git
+
+WORKDIR /home/node/app
+RUN chown -R node:node /home/node/app
+USER node:node
+ARG TAG_VERSION=master
+RUN git clone -b ${TAG_VERSION} --single-branch https://github.com/OpenBankingUK/reference-mock-server.git /home/node/app/reference-mock-server
+WORKDIR /home/node/app/reference-mock-server
+RUN npm install
+
+RUN cp .env.sample .env
+EXPOSE 8001
+CMD ["npm", "run", "foreman"]
+

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The `.env` file configures the following variables:
 * `DEBUG =error,log`
 * `HOST=http://localhost:8001`
 * `OPENID_ASPSP_AUTH_HOST=http://localhost:8001`
+* `OPENID_ASPSP_TOKEN_HOST=http://localhost:8001`
 * `OPENID_CONFIG_ENDPOINT_URL=http://localhost:8001/openid/config`
 * `PAYMENT_SWAGGER=<JSON swagger spec URI or file path>`
 * `PORT=8001`

--- a/README.md
+++ b/README.md
@@ -21,14 +21,45 @@ git checkout v0.7.0
 
 Note: latest `master` branch code is actively under development and may not be stable.
 
-## To run
+## Installation
+
+Below are instructions for [installing via docker](#installation-via-docker),
+and alternatively [installing directly on your local machine](#installation-on-local-machine).
+
+### Installation via Docker
+
+To install as a container-based app we assume
+[Docker](https://www.docker.com/community-edition) ver17.12+ is installed.
+
+If not installed you can find [Docker Community Edition downloads here](https://www.docker.com/community-edition#/download).
+
+To build docker image:
+
+```sh
+cd reference-mock-server
+docker build -t ob/reference-mock-server --build-arg TAG_VERSION=v0.x.0 .
+```
+
+Use `docker images` command to check `ob/reference-mock-server` and `node` have
+been created:
+
+```sh
+docker images
+# REPOSITORY                 TAG                 ...
+# ob/reference-mock-server   latest              ...
+# node                       8.4-alpine          ...
+```
+
+### Installation on Local Machine
+
+We assume [NodeJS](https://nodejs.org/en/) ver8.4+ is installed.
 
 Install npm packages:
 
 ```sh
+cd reference-mock-server
 npm install
 ```
-
 Several environment variables are used to configure the mock server.
 
 The mock server reads swagger files to generate endpoints for Account Information

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ docker images
 # node                       8.4-alpine          ...
 ```
 
+To run the mock server container together with the TPP reference server follow the
+[TPP reference server Docker install steps](https://github.com/OpenBankingUK/tpp-reference-server/blob/master/README-DOCKER.md#installation-via-docker---for-quick-start-with-mocked-api).
+Following those steps will start both servers together.
+
+If you want to run **only** the mock server *without the TPP reference server*, you
+can run:
+
+```sh
+docker-compose up
+```
+
+
 ### Installation on Local Machine
 
 We assume [NodeJS](https://nodejs.org/en/) ver8.4+ is installed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,5 @@
 version: '3'
 services:
-  redis:
-    image: "redis:alpine"
-    ports:
-     - "6379:6379"
-  mongo:
-    image: "mongo:3.6"
-    ports:
-     - "27017:27017"
   web:
     build: .
     image: ob/reference-mock-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  redis:
+    image: "redis:alpine"
+    ports:
+     - "6379:6379"
+  mongo:
+    image: "mongo:3.6"
+    ports:
+     - "27017:27017"
+  web:
+    build: .
+    image: ob/reference-mock-server
+    ports:
+     - "8001:8001"

--- a/lib/aspsp-open-id-config/index.js
+++ b/lib/aspsp-open-id-config/index.js
@@ -2,6 +2,7 @@ const env = require('env-var');
 const log = require('debug')('log');
 
 const openidAspspAuthHost = env.get('OPENID_ASPSP_AUTH_HOST').asString();
+const openidAspspTokenHost = env.get('OPENID_ASPSP_TOKEN_HOST').asString();
 
 const get = (req, res) => {
   const aspspId = req.params.id;
@@ -9,7 +10,7 @@ const get = (req, res) => {
 
   res.json({
     authorization_endpoint: `${openidAspspAuthHost}/${aspspId}/authorize`,
-    token_endpoint: `${openidAspspAuthHost}/${aspspId}/token`,
+    token_endpoint: `${openidAspspTokenHost || openidAspspAuthHost}/${aspspId}/token`,
     scopes_supported: ['openid', 'accounts', 'payments'],
     id_token_signing_alg_values_supported: ['none'],
     request_object_signing_alg_values_supported: ['none'],


### PR DESCRIPTION
- Add Dockerfile to create image of reference mock server
- Use OPENID_ASPSP_TOKEN_HOST env var to configure token host separately from auth host for docker container usage.
- Add docker-compose to start reference-mock-server for use without tpp-reference-server

To build mock server image with branch code for testing:
> docker build -t ob/reference-mock-server --build-arg TAG_VERSION=dockerised .

