### PR TITLE
GET account-request is always `Authorised`

### DIFF
--- a/lib/aspsp-resource-server/account-request.js
+++ b/lib/aspsp-resource-server/account-request.js
@@ -66,22 +66,20 @@ const accountRequestHelper = (() => {
     return response;
   };
 
-  const buildPostResponse = (accountRequestId, requestData) => {
+  const buildPostResponse = (accountRequestId, requestData, status = 'AwaitingAuthorisation') => {
     const d = new Date();
     const creation = `${d.toISOString().slice(0, -5)}+00:00`;
     d.setFullYear(d.getFullYear() + 1);
     const expiration = `${d.toISOString().slice(0, -5)}+00:00`; // Assume one year's time
     const reqData = requestData || {
       ExpirationDateTime: expiration, // Spoof
-      TransactionFromDateTime: null,
-      TransactionToDateTime: null,
       Permissions: [],
     };
 
     /* Possible Statuses - Authorised AwaitingAuthorisation Rejected Revoked  */
     const data = {
       AccountRequestId: accountRequestId,
-      Status: 'AwaitingAuthorisation', // Spoof, default status
+      Status: status, // Spoof status
       CreationDateTime: creation,
       ExpirationDateTime: reqData.ExpirationDateTime,
       TransactionFromDateTime: reqData.TransactionFromDateTime,

--- a/lib/aspsp-resource-server/account-requests.js
+++ b/lib/aspsp-resource-server/account-requests.js
@@ -1,5 +1,6 @@
 // See https://openbanking.atlassian.net/wiki/spaces/WOR/pages/5785171/Account+and+Transaction+API+Specification+-+v1.1.0#AccountandTransactionAPISpecification-v1.1.0-Request
 const { accountRequestHelper } = require('./account-request.js');
+const log = require('debug')('log');
 
 const accountRequests = (() => {
   const post = (req, res) => {
@@ -24,9 +25,17 @@ const accountRequests = (() => {
   const get = (req, res) => {
     const authorization = req.headers['authorization']; // eslint-disable-line
     const authorized = accountRequestHelper.checkAuthorization({ authorization });
+    log(`accountRequests#get authorized: ${authorized}`);
+
     const interactionId = req.headers['x-fapi-interaction-id'] || '';
-    const accountRequestId = req.params.id;
-    const accountRequest = accountRequestHelper.getCachedAccountRequest(accountRequestId);
+    log(`accountRequests#get interactionId: ${interactionId}`);
+
+    const accountRequestId = req.pathParams.AccountRequestId;
+    log(`accountRequests#get accountRequestId: ${accountRequestId}`);
+
+    const accountRequest = accountRequestHelper.buildPostResponse(accountRequestId, null, 'Authorised');
+    log(`accountRequests#get accountRequest: ${JSON.stringify(accountRequest)}`);
+
     if (!authorized) {
       res.sendStatus(401);
     }

--- a/lib/aspsp-resource-server/account-requests.js
+++ b/lib/aspsp-resource-server/account-requests.js
@@ -24,6 +24,8 @@ const accountRequests = (() => {
 
   const get = (req, res) => {
     const authorization = req.headers['authorization']; // eslint-disable-line
+    log(`accountRequests#get authorization: ${authorization}`);
+
     const authorized = accountRequestHelper.checkAuthorization({ authorization });
     log(`accountRequests#get authorized: ${authorized}`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2887,11 +2887,6 @@
       "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
       "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2901,6 +2896,11 @@
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "strip-ansi": {
       "version": "4.0.0",


### PR DESCRIPTION
All requests to `GET` `/account-requests/{AccountRequestId}` will return a fake pre-packaged AccountRequest with `Status` set to `Authorised`.

This is required to pass `e2e` on the TPP Client.