### PR TITLE
Disable x-powered-by header on responses

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -7,6 +7,7 @@ const morgan = require('morgan');
 const errorHandler = require('../lib/errors/error-handler');
 
 const app = express();
+app.disable('x-powered-by');
 
 if (process.env.NODE_ENV !== 'test') { // don't log requests when testing
   app.use(morgan('dev')); // for logging


### PR DESCRIPTION
Not required for API simulation.