### PR TITLE
REFAPP-289 headless consent for mock server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,6 +5,7 @@ BANK_DATA_DIRECTORY=abcbank
 CLIENT_ID=spoofClientId
 CLIENT_SECRET=spoofClientSecret
 DEBUG=error,log
+HEADLESS_CONSENT=false
 HOST=http://localhost:8001
 OPENID_ASPSP_AUTH_HOST=http://localhost:8001
 OPENID_ASPSP_TOKEN_HOST=http://localhost:8001

--- a/lib/aspsp-authorisation-server/authorise.js
+++ b/lib/aspsp-authorisation-server/authorise.js
@@ -9,6 +9,7 @@
 const log = require('debug')('log');
 const env = require('env-var');
 const { validate } = require('./validate');
+const headlessConsentEnabled = () => process.env.HEADLESS_CONSENT === 'true';
 
 const consentReqPage = `<html>
   <head></head>
@@ -42,7 +43,7 @@ const authorise = (req, res) => {
 
   validate(req.query);
 
-  if (approve) {
+  if (approve || headlessConsentEnabled()) {
     const { client_id: clientId } = query;
     const { state, request: signedJWTrequest } = query;
 

--- a/lib/aspsp-authorisation-server/authorise.js
+++ b/lib/aspsp-authorisation-server/authorise.js
@@ -9,6 +9,7 @@
 const log = require('debug')('log');
 const env = require('env-var');
 const { validate } = require('./validate');
+
 const headlessConsentEnabled = () => process.env.HEADLESS_CONSENT === 'true';
 
 const consentReqPage = `<html>

--- a/test/aspsp-authorisation-server/authorise-test.js
+++ b/test/aspsp-authorisation-server/authorise-test.js
@@ -6,7 +6,6 @@ const proxyquire = require('proxyquire');
 const env = require('env-var');
 
 describe('/authorize endpoint test', () => {
-  let authoriseService;
   const state = '123456';
   const aspspCallbackRedirectionUrl = 'http://example.com/aaa-bank-url';
   const authorsationCode = 'ABCD123456789';
@@ -20,79 +19,78 @@ describe('/authorize endpoint test', () => {
     scope: 'openid accounts',
   };
 
-  before(() => {
-    process.env.AUTHORISATION_CODE = authorsationCode;
-    authoriseService = proxyquire('../../lib/aspsp-authorisation-server/authorise', {
-      'env-var': env.mock({
-        AUTHORISATION_CODE: authorsationCode,
-      }),
-    });
-  });
+  process.env.AUTHORISATION_CODE = authorsationCode;
+  const { authorise } = (proxyquire('../../lib/aspsp-authorisation-server/authorise', {
+    'env-var': env.mock({
+      AUTHORISATION_CODE: authorsationCode,
+    }),
+  }));
 
-
-  it('Validate successful ASPSP AS authorisation and display consent approval page for account flow ', () => {
-    const { authorise } = authoriseService;
-    const query = Object.assign({}, refQuery);
-    const req = httpMocks.createRequest({
+  const createRequest = (opts = {}) => {
+    const query = Object.assign({}, refQuery, opts);
+    return httpMocks.createRequest({
       method: 'GET',
       url: '/aaa-bank/authorize',
       query,
     });
-    const res = httpMocks.createResponse();
-    authorise(req, res);
-    assert.ok(res._getData().includes('Welcome to the bank')); //eslint-disable-line
-    assert.equal(res.statusCode, 200);
-  });
+  };
 
-  it('Validate successful ASPSP AS authorisation with approved consent for account flow ', () => {
-    const { authorise } = authoriseService;
-    const query = Object.assign({}, refQuery, { approve: 1 });
-    const req = httpMocks.createRequest({
-      method: 'GET',
-      url: '/aaa-bank/authorize',
-      query,
-    });
-    const res = httpMocks.createResponse();
-    authorise(req, res);
+  const assertRedirectionSuccessful = (res) => {
     assert.equal(res.statusCode, 302);
     const location = res._getRedirectUrl();  //eslint-disable-line
     assert.ok(location);
     assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
     assert.ok(location.includes(`code=${authorsationCode}`));
     assert.ok(location.includes(`state=${state}`));
+  }
+
+  afterEach(() => {
+    process.env.HEADLESS_CONSENT = 'false';
   });
 
-  it('Validate successful ASPSP AS authorisation with approved consent for payment flow ', () => {
-    const { authorise } = authoriseService;
-    const query = Object.assign({}, refQuery, { scope: 'openid payments', approve: 1 });
-    const req = httpMocks.createRequest({
-      method: 'GET',
-      url: '/aaa-bank/authorize',
-      query,
+  describe('consent approval page', () => {
+    it('should display when approval required and query params are valid', () => {
+      const req = createRequest();
+      const res = httpMocks.createResponse();
+      authorise(req, res);
+      assert.equal(res.statusCode, 200);
+      assert.ok(res._getData().includes('Welcome to the bank')); //eslint-disable-line
     });
-    const res = httpMocks.createResponse();
-    authorise(req, res);
-    assert.equal(res.statusCode, 302);
-    const location = res._getRedirectUrl();  //eslint-disable-line
-    assert.ok(location);
-    assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
-    assert.ok(location.includes(`code=${authorsationCode}`));
-    assert.ok(location.includes(`state=${state}`));
+
+    it('should be bypassed for headless consent and query params are valid', () => {
+      process.env.HEADLESS_CONSENT = 'true';
+      const req = createRequest();
+      const res = httpMocks.createResponse();
+      authorise(req, res);
+      assertRedirectionSuccessful(res);
+    });
   });
 
-  it('Validate successful ASPSP AS authorisation with not approved consent for payment flow ', async () => {
-    const { authorise } = authoriseService;
-    const query = Object.assign({}, refQuery, { scope: 'openid payments', cancel: 1 });
-    const req = httpMocks.createRequest({
-      method: 'GET',
-      url: '/aaa-bank/authorize',
-      query,
+  describe('approved consent', () => {
+    it('should redirect for account flow when query params are valid', () => {
+      const req = createRequest({ scope: 'openid accounts', approve: 1 });
+      const res = httpMocks.createResponse();
+      authorise(req, res);
+      assertRedirectionSuccessful(res);
     });
-    const res = httpMocks.createResponse();
-    try {
-      await authorise(req, res);
-    } catch (e) {
-      assert.equal(e.message, 'Redirection due to access_denied');
-    }
+
+    it('should redirect for payment flow when query params are valid', () => {
+      const req = createRequest({ scope: 'openid payments', approve: 1 });
+      const res = httpMocks.createResponse();
+      authorise(req, res);
+      assertRedirectionSuccessful(res);
+    });
+  });
+
+  describe('consent not approved', () => {
+    it('should throw an exception ', async () => {
+      const req = createRequest({ scope: 'openid payments', cancel: 1 });
+      const res = httpMocks.createResponse();
+      try {
+        await authorise(req, res);
+      } catch (e) {
+        assert.equal(e.message, 'Redirection due to access_denied');
+      }
+    });
   });
 });

--- a/test/aspsp-authorisation-server/authorise-test.js
+++ b/test/aspsp-authorisation-server/authorise-test.js
@@ -42,7 +42,7 @@ describe('/authorize endpoint test', () => {
     assert.ok(location.startsWith(aspspCallbackRedirectionUrl));
     assert.ok(location.includes(`code=${authorsationCode}`));
     assert.ok(location.includes(`state=${state}`));
-  }
+  };
 
   afterEach(() => {
     process.env.HEADLESS_CONSENT = 'false';

--- a/test/aspsp-authorisation-server/authorise-test.js
+++ b/test/aspsp-authorisation-server/authorise-test.js
@@ -88,6 +88,7 @@ describe('/authorize endpoint test', () => {
       const res = httpMocks.createResponse();
       try {
         await authorise(req, res);
+        assert.fail(new Error('Authorise should have failed.'));
       } catch (e) {
         assert.equal(e.message, 'Redirection due to access_denied');
       }


### PR DESCRIPTION
We use a new ENV `HEADLESS_CONSENT=false` to allow headless consent.

New test added and older tests refactored to remove repetition.