### PR TITLE
Fixed issue with npm run foreman

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": "8.4.0"
   },
   "scripts": {
-    "foreman": "./node_modules/foreman/nf.js start",
+    "foreman": "node ./node_modules/foreman/nf.js start",
     "start": "node index.js",
     "eslint": "node ./node_modules/eslint/bin/eslint.js .",
     "checks": "npm run eslint && npm test ",


### PR DESCRIPTION
This was not working on windows either via `cmd` or via a `cmder bash` window.

This fix simply adds an `node` in front of the statement.
